### PR TITLE
Added enemy navigation, collisions, main scene, food projectiles, enemy health

### DIFF
--- a/DefendTheKitchen/Enemy.gd
+++ b/DefendTheKitchen/Enemy.gd
@@ -1,0 +1,37 @@
+extends KinematicBody2D
+
+onready var navigationAgent = $NavigationAgent2D;
+
+signal pathChanged(path);
+
+export (NodePath) var playerNodePath;
+var player = null;
+var velocity = Vector2.ZERO;
+export var maxSpeed = 1.0;
+
+func _ready():
+	player = get_node(playerNodePath);
+	navigationAgent.set_target_location(player.global_position);
+	navigationAgent.max_speed = maxSpeed;
+
+
+func _process(delta):
+	CalculateMovement(delta);
+		
+
+func CalculateMovement(delta):
+	if player != null:
+		# move towards the player
+		navigationAgent.set_target_location(player.global_position);
+		var moveDirection = position.direction_to(navigationAgent.get_next_location());
+		velocity = moveDirection * maxSpeed * delta;
+		navigationAgent.set_velocity(velocity);
+
+# signal called by set_velocity() method of navigationAgent
+func _on_NavigationAgent2D_velocity_computed(safe_velocity):
+	velocity = safe_velocity;
+	var _newVelocity = move_and_slide(velocity);
+
+# emit information needed to draw enemy's desired path
+func _on_NavigationAgent2D_path_changed():
+	emit_signal("pathChanged",navigationAgent.get_nav_path());

--- a/DefendTheKitchen/Enemy.gd
+++ b/DefendTheKitchen/Enemy.gd
@@ -8,6 +8,10 @@ export (NodePath) var playerNodePath;
 var player = null;
 var velocity = Vector2.ZERO;
 export var maxSpeed = 1.0;
+# since we aren't currently changing the sprite to make the enemy look fatter, we just change the size of the sprite
+export var damageSpriteScaleFactor = 1.25;
+var isDead = false;
+var healthPoints = 3;
 
 func _ready():
 	player = get_node(playerNodePath);
@@ -16,21 +20,41 @@ func _ready():
 
 
 func _process(delta):
+	if isDead:
+		return;
 	CalculateMovement(delta);
 		
 
-func CalculateMovement(delta):
+func CalculateMovement(_delta):
 	if player != null:
 		# move towards the player
 		navigationAgent.set_target_location(player.global_position);
 		var moveDirection = position.direction_to(navigationAgent.get_next_location());
-		velocity = moveDirection * maxSpeed * delta;
+		velocity = moveDirection * maxSpeed;
 		navigationAgent.set_velocity(velocity);
+		
+		
+		
+func takeDamage(damage):
+	if not isDead:
+		healthPoints -= damage;
+		# increase size of enemy
+		$AnimatedSprite.scale *= damageSpriteScaleFactor;
+		$CollisionShape2D.shape.radius *= damageSpriteScaleFactor;
+		if healthPoints <= 0:
+			die();
+func die():
+	if not isDead:
+		isDead = true;
+		queue_free();
 
 # signal called by set_velocity() method of navigationAgent
 func _on_NavigationAgent2D_velocity_computed(safe_velocity):
 	velocity = safe_velocity;
-	var _newVelocity = move_and_slide(velocity);
+	var _velocity = move_and_slide(velocity);
+	for index in get_slide_count():
+		var collision := get_slide_collision(index);
+		var body := collision.collider;
 
 # emit information needed to draw enemy's desired path
 func _on_NavigationAgent2D_path_changed():

--- a/DefendTheKitchen/Enemy.tscn
+++ b/DefendTheKitchen/Enemy.tscn
@@ -1,0 +1,33 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://Enemy.gd" type="Script" id=2]
+
+[sub_resource type="SpriteFrames" id=1]
+animations = [ {
+"frames": [ ExtResource( 1 ) ],
+"loop": true,
+"name": "default",
+"speed": 5.0
+} ]
+
+[sub_resource type="CircleShape2D" id=2]
+radius = 21.0238
+
+[node name="Enemy" type="KinematicBody2D"]
+script = ExtResource( 2 )
+maxSpeed = 10000.0
+
+[node name="AnimatedSprite" type="AnimatedSprite" parent="."]
+rotation = 1.5708
+scale = Vector2( 0.7, 0.7 )
+frames = SubResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 2 )
+
+[node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
+avoidance_enabled = true
+
+[connection signal="path_changed" from="NavigationAgent2D" to="." method="_on_NavigationAgent2D_path_changed"]
+[connection signal="velocity_computed" from="NavigationAgent2D" to="." method="_on_NavigationAgent2D_velocity_computed"]

--- a/DefendTheKitchen/Enemy.tscn
+++ b/DefendTheKitchen/Enemy.tscn
@@ -14,9 +14,11 @@ animations = [ {
 [sub_resource type="CircleShape2D" id=2]
 radius = 21.0238
 
-[node name="Enemy" type="KinematicBody2D"]
+[node name="Enemy" type="KinematicBody2D" groups=["enemies"]]
+collision_layer = 2
+collision_mask = 13
 script = ExtResource( 2 )
-maxSpeed = 10000.0
+maxSpeed = 80.0
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 rotation = 1.5708

--- a/DefendTheKitchen/ExampleObstacle.tscn
+++ b/DefendTheKitchen/ExampleObstacle.tscn
@@ -1,0 +1,23 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://icon.png" type="Texture" id=1]
+
+[sub_resource type="SpriteFrames" id=1]
+animations = [ {
+"frames": [ ExtResource( 1 ) ],
+"loop": true,
+"name": "default",
+"speed": 5.0
+} ]
+
+[sub_resource type="RectangleShape2D" id=2]
+extents = Vector2( 31, 30 )
+
+[node name="ExampleObstacle" type="StaticBody2D"]
+
+[node name="AnimatedSprite" type="AnimatedSprite" parent="."]
+frames = SubResource( 1 )
+flip_v = true
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 2 )

--- a/DefendTheKitchen/Food.gd
+++ b/DefendTheKitchen/Food.gd
@@ -1,0 +1,20 @@
+extends KinematicBody2D
+
+var direction = Vector2.ZERO;
+export var speed = 1000.0;
+export var rotationSpeed = 2.0;
+var screen_size = Vector2.ZERO;
+
+
+func _ready():
+	screen_size = get_viewport_rect().size;
+
+func _process(_delta):
+	if position.x > screen_size.x or position.x < 0 or position.y > screen_size.y or position.y < 0:
+		destroy();
+	
+func start():
+	pass
+	
+func destroy():
+	queue_free();

--- a/DefendTheKitchen/Food.tscn
+++ b/DefendTheKitchen/Food.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=5 format=2]
 
 [ext_resource path="res://icon.png" type="Texture" id=1]
+[ext_resource path="res://Food.gd" type="Script" id=2]
 
 [sub_resource type="SpriteFrames" id=1]
 animations = [ {
@@ -10,16 +11,18 @@ animations = [ {
 "speed": 5.0
 } ]
 
-[sub_resource type="RectangleShape2D" id=2]
-extents = Vector2( 31, 30 )
+[sub_resource type="CircleShape2D" id=2]
+radius = 12.1655
 
-[node name="ExampleObstacle" type="StaticBody2D"]
-collision_layer = 4
-collision_mask = 11
+[node name="Food" type="KinematicBody2D"]
+collision_layer = 8
+collision_mask = 6
+script = ExtResource( 2 )
+speed = 30000.0
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
+scale = Vector2( 0.4, 0.4 )
 frames = SubResource( 1 )
-flip_v = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )

--- a/DefendTheKitchen/Main.gd
+++ b/DefendTheKitchen/Main.gd
@@ -1,0 +1,6 @@
+extends Node
+
+onready var line = $Line2D;
+
+func _on_Enemy_pathChanged(path):
+	line.points = path;

--- a/DefendTheKitchen/Main.tscn
+++ b/DefendTheKitchen/Main.tscn
@@ -17,6 +17,7 @@ script = ExtResource( 4 )
 navpoly = SubResource( 1 )
 
 [node name="Line2D" type="Line2D" parent="."]
+visible = false
 width = 5.0
 default_color = Color( 0.886275, 0.886275, 0.886275, 1 )
 

--- a/DefendTheKitchen/Main.tscn
+++ b/DefendTheKitchen/Main.tscn
@@ -1,0 +1,38 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://Enemy.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Player.tscn" type="PackedScene" id=2]
+[ext_resource path="res://ExampleObstacle.tscn" type="PackedScene" id=3]
+[ext_resource path="res://Main.gd" type="Script" id=4]
+
+[sub_resource type="NavigationPolygon" id=1]
+vertices = PoolVector2Array( 1024, 3, 1024, 597, 397, 158, 380, 107, 360, 205, -1, 603, 294, 273, 235, 293, 190, 278, 3, 3, 178, 233, 241, 167, 312, 110 )
+polygons = [ PoolIntArray( 0, 1, 2, 3 ), PoolIntArray( 4, 2, 1 ), PoolIntArray( 4, 1, 5, 6 ), PoolIntArray( 7, 6, 5 ), PoolIntArray( 8, 7, 5 ), PoolIntArray( 8, 5, 9, 10 ), PoolIntArray( 11, 10, 9 ), PoolIntArray( 9, 0, 3, 12 ), PoolIntArray( 9, 12, 11 ) ]
+outlines = [ PoolVector2Array( 3, 3, -1, 603, 1024, 597, 1024, 3 ), PoolVector2Array( 241, 167, 178, 233, 190, 278, 235, 293, 294, 273, 360, 205, 397, 158, 380, 107, 312, 110 ) ]
+
+[node name="Main" type="Node"]
+script = ExtResource( 4 )
+
+[node name="NavigationPolygonInstance" type="NavigationPolygonInstance" parent="."]
+navpoly = SubResource( 1 )
+
+[node name="Line2D" type="Line2D" parent="."]
+width = 5.0
+default_color = Color( 0.886275, 0.886275, 0.886275, 1 )
+
+[node name="Player" parent="." instance=ExtResource( 2 )]
+
+[node name="Enemy" parent="." instance=ExtResource( 1 )]
+position = Vector2( 690, 96 )
+playerNodePath = NodePath("../Player")
+
+[node name="ExampleObstacle" parent="." instance=ExtResource( 3 )]
+position = Vector2( 292, 201 )
+
+[node name="ExampleObstacle2" parent="." instance=ExtResource( 3 )]
+position = Vector2( 344, 152 )
+
+[node name="ExampleObstacle3" parent="." instance=ExtResource( 3 )]
+position = Vector2( 239, 242 )
+
+[connection signal="pathChanged" from="Enemy" to="." method="_on_Enemy_pathChanged"]

--- a/DefendTheKitchen/Pizza.gd
+++ b/DefendTheKitchen/Pizza.gd
@@ -1,0 +1,16 @@
+extends "res://Food.gd"
+
+func _process(delta):
+	rotation += rotationSpeed * delta;
+
+func _physics_process(_delta):
+	var _velocity = move_and_slide(direction * speed);
+	for index in get_slide_count():
+		var collision := get_slide_collision(index);
+		var body := collision.collider;
+		if body.is_in_group("enemies"):
+			body.takeDamage(1.0);
+			
+		
+		destroy();
+		break;

--- a/DefendTheKitchen/Pizza.tscn
+++ b/DefendTheKitchen/Pizza.tscn
@@ -1,0 +1,13 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Food.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Pizza.gd" type="Script" id=2]
+
+[sub_resource type="CircleShape2D" id=1]
+
+[node name="Pizza" instance=ExtResource( 1 )]
+script = ExtResource( 2 )
+speed = 200.0
+
+[node name="CollisionShape2D" parent="." index="1"]
+shape = SubResource( 1 )

--- a/DefendTheKitchen/Player.gd
+++ b/DefendTheKitchen/Player.gd
@@ -1,16 +1,19 @@
-extends Area2D
+extends KinematicBody2D
 
 
 export var speed = 400.0;
 var screen_size = Vector2.ZERO;
-
+var direction = Vector2.ZERO;
 
 func _ready():
 	screen_size = get_viewport_rect().size;
 
 
-func _process(delta):
-	var direction = Vector2.ZERO;
+func _process(_delta):
+	GetInput();
+
+func GetInput():
+	direction = Vector2.ZERO;
 	if Input.is_action_pressed("move_right"):
 		direction.x += 1;
 	if Input.is_action_pressed("move_left"):
@@ -19,7 +22,10 @@ func _process(delta):
 		direction.y += 1;
 	if Input.is_action_pressed("move_up"):
 		direction.y -= 1;
-		
-	position += direction * speed * delta;
+
+func _physics_process(delta):
+	var _newVelocity = move_and_slide(direction * speed * delta)
+	# keep player within screen
 	position.x = clamp(position.x,0,screen_size.x);
 	position.y = clamp(position.y,0,screen_size.y);
+

--- a/DefendTheKitchen/Player.gd
+++ b/DefendTheKitchen/Player.gd
@@ -4,6 +4,12 @@ extends KinematicBody2D
 export var speed = 400.0;
 var screen_size = Vector2.ZERO;
 var direction = Vector2.ZERO;
+var aimDirection = Vector2.ZERO;
+var foods = {
+	"pizza" : preload("res://Pizza.tscn")
+}
+
+
 
 func _ready():
 	screen_size = get_viewport_rect().size;
@@ -22,10 +28,20 @@ func GetInput():
 		direction.y += 1;
 	if Input.is_action_pressed("move_up"):
 		direction.y -= 1;
+	aimDirection = (get_global_mouse_position() - global_position).normalized();
+	if Input.is_action_just_pressed("mouse_click"):
+		ThrowFood();
+		
 
-func _physics_process(delta):
-	var _newVelocity = move_and_slide(direction * speed * delta)
+func _physics_process(_delta):
+	var _newVelocity = move_and_slide(direction * speed)
 	# keep player within screen
 	position.x = clamp(position.x,0,screen_size.x);
 	position.y = clamp(position.y,0,screen_size.y);
 
+func ThrowFood():
+	var b = foods["pizza"].instance();
+	b.direction = aimDirection;
+	owner.add_child(b);
+	b.global_position = global_position;
+	

--- a/DefendTheKitchen/Player.tscn
+++ b/DefendTheKitchen/Player.tscn
@@ -14,10 +14,10 @@ animations = [ {
 "speed": 5.0
 } ]
 
-[node name="Player" type="Area2D"]
+[node name="Player" type="KinematicBody2D"]
 position = Vector2( 494, 267 )
 script = ExtResource( 2 )
-speed = 200.0
+speed = 7000.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 1 )

--- a/DefendTheKitchen/Player.tscn
+++ b/DefendTheKitchen/Player.tscn
@@ -16,8 +16,9 @@ animations = [ {
 
 [node name="Player" type="KinematicBody2D"]
 position = Vector2( 494, 267 )
+collision_mask = 6
 script = ExtResource( 2 )
-speed = 7000.0
+speed = 140.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 1 )

--- a/DefendTheKitchen/project.godot
+++ b/DefendTheKitchen/project.godot
@@ -11,6 +11,7 @@ config_version=4
 [application]
 
 config/name="DefendTheKitchen"
+run/main_scene="res://Main.tscn"
 config/icon="res://icon.png"
 
 [display]

--- a/DefendTheKitchen/project.godot
+++ b/DefendTheKitchen/project.godot
@@ -19,6 +19,10 @@ config/icon="res://icon.png"
 window/stretch/mode="2d"
 window/stretch/aspect="keep"
 
+[global]
+
+layer=false
+
 [gui]
 
 common/drop_mouse_on_gui_input_disabled=true
@@ -45,6 +49,18 @@ move_down={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":83,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
+mouse_click={
+"deadzone": 0.5,
+"events": [ Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"button_mask":0,"position":Vector2( 0, 0 ),"global_position":Vector2( 0, 0 ),"factor":1.0,"button_index":1,"pressed":false,"doubleclick":false,"script":null)
+ ]
+}
+
+[layer_names]
+
+2d_physics/layer_1="Player"
+2d_physics/layer_2="Enemy"
+2d_physics/layer_3="Wall"
+2d_physics/layer_4="FoodProjectile"
 
 [physics]
 


### PR DESCRIPTION
Currently the area in which the enemy can move is predetermined before the game starts. This will be an issue to address once the kitchen's geometry/layout can be modified since the enemy will need to know the updated layout in order to correctly calculate a path to the player.

Also the line drawing the enemy's path to the player is just for debug purposes and will not be in the final game.