### PR TITLE
enemy types, waves, collisions, navigation

### DIFF
--- a/DefendTheKitchen/Enemy.gd
+++ b/DefendTheKitchen/Enemy.gd
@@ -1,52 +1,68 @@
 extends KinematicBody2D
 
+# This is the "abstract" class that all enemy types inherit from
+
+
+
+
 onready var navigationAgent = $NavigationAgent2D;
 
 signal pathChanged(path);
+signal died(_self);
 
-export (NodePath) var playerNodePath;
 var player = null;
 var velocity = Vector2.ZERO;
-export var maxSpeed = 1.0;
-# since we aren't currently changing the sprite to make the enemy look fatter, we just change the size of the sprite
-export var damageSpriteScaleFactor = 1.25;
+export (float) var maxSpeed = 70.0;
 var isDead = false;
 var canMove = true;
 export var canMoveOnAttack = true;
 var isAttacking = false;
 var canAttack = true;
-export var attackCooldown = 1.0;
-export var attackWindup = 1.0;
-export var attackDistance = 200;
-export var healthPoints = 3;
-var currentColor = Color(1,1,1);
+export (float) var attackCooldown;
+export (float) var attackWindup;
+export (float) var attackDistance;
+export var healthPoints = 1;
+export var currentColor = Color(1,1,1);
+
+var normalEnemyPrefab = load("res://Enemy_Normal.tscn");
+var bigEnemyPrefab = load("res://Enemy_Big.tscn");
+var fastEnemyPrefab = load("res://Enemy_Fast.tscn");
+
+# thresholds that determine which navigation polygon (tight, normal, or wide) the enemy should be attached to
+var navigationPolygonThresholds = {
+	"tight" : 0.5,
+	"normal" : 0.7,
+	"big" : 1.1
+};
 
 func _ready():
-	player = get_node("../Player");
+	
+	player = get_node("../../Player");
 	navigationAgent.set_target_location(player.global_position);
 	navigationAgent.max_speed = maxSpeed;
 	$AnimatedSprite.modulate = currentColor;
+	
 
 func _process(delta):
 	if isDead:
 		return;
 	CalculateMovement(delta);
 
+func _test():
+	print("test");
 		
 func _physics_process(_delta):
-	if player != null:
-		if isDead:
-			return;
+	if isDead:
+		return;
 	
-		# if we are close enough to player then attack
-		if canAttack and (player.global_position - global_position).length_squared() < attackDistance*attackDistance:
-			
-			# ensure that there is nothing between us and the player
-			var space_state = get_world_2d().direct_space_state;
-			var raycastResult = space_state.intersect_ray(global_position,player.global_position,[self],0b0001)
-			if raycastResult:
-			
-				attackPlayer();
+	# if we are close enough to player then attack
+	if canAttack and (player.global_position - global_position).length_squared() < attackDistance*attackDistance:
+		
+		# ensure that there is nothing between us and the player
+		var space_state = get_world_2d().direct_space_state;
+		var raycastResult = space_state.intersect_ray(global_position,player.global_position,[self],0b0001)
+		if raycastResult:
+			StartAttack();
 		
 
 func CalculateMovement(_delta):
@@ -63,17 +79,15 @@ func takeDamage(damage):
 	if not isDead:
 		healthPoints -= damage;
 		currentColor *= .5
-		$AnimatedSprite.modulate = currentColor;
-		
-		# increase size of enemy
-		# not doing this right now because of collision issues
-		#$AnimatedSprite.scale *= damageSpriteScaleFactor;
-		#$CollisionShape2D.shape.radius *= damageSpriteScaleFactor;
+		$AnimatedSprite.modulate = currentColor;	
 		if healthPoints <= 0:
 			die();
+
 func die():
 	if not isDead:
 		isDead = true;
+		emit_signal("died",self);
+		get_parent().call_deferred("remove_child",self);
 		queue_free();
 
 func disable():
@@ -90,28 +104,30 @@ func _on_NavigationAgent2D_velocity_computed(safe_velocity):
 # emit information needed to draw enemy's desired path
 func _on_NavigationAgent2D_path_changed():
 	emit_signal("pathChanged",navigationAgent.get_nav_path());
-
-
-func attackPlayer():
-	if player != null:
-		isAttacking = true;
-		canAttack = false;
-		print("starting attack...")
-		if not canMoveOnAttack:
-			canMove = false;
-		$AnimatedSprite.modulate = Color(1,0,0);
-		yield(get_tree().create_timer(attackWindup),"timeout");
-		if (player.global_position - global_position).length_squared() < attackDistance*attackDistance and not isDead:
-			player.takeDamage(1.0)
-			print("hit")
-		else:
-			print("missed")
 	
-		if not canMoveOnAttack:
-			canMove = true;
-		$AnimatedSprite.modulate = currentColor;
-		isAttacking = false;
-		yield(get_tree().create_timer(attackCooldown),"timeout");
-		canAttack = true;
-	
+func StartAttack():
+	isAttacking = true;
+	canAttack = false;
+	if not canMoveOnAttack:
+		canMove = false;
+	$AnimatedSprite.modulate = Color(1,0,0);
+	$AttackWindupTimer.start(attackWindup);
 
+func _on_AttackWindupTimer_timeout():
+	if (player.global_position - global_position).length_squared() < attackDistance*attackDistance and not isDead:
+		player.takeDamage(1.0);
+	
+	if not canMoveOnAttack:
+		canMove = true;
+	$AnimatedSprite.modulate = currentColor;
+	isAttacking = false;
+	$AttackCooldownTimer.start(attackCooldown);
+
+
+func _on_AttackCooldownTimer_timeout():
+	canAttack = true;
+
+
+func _on_Area2D_area_entered(area):
+	if area.get_parent().is_in_group("food"):
+		area.get_parent().HitEnemy(self);

--- a/DefendTheKitchen/Enemy.tscn
+++ b/DefendTheKitchen/Enemy.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://Art/icon.png" type="Texture" id=1]
 [ext_resource path="res://Enemy.gd" type="Script" id=2]
@@ -14,25 +14,41 @@ animations = [ {
 [sub_resource type="CircleShape2D" id=2]
 radius = 21.0238
 
+[sub_resource type="CircleShape2D" id=3]
+radius = 21.095
+
 [node name="Enemy" type="KinematicBody2D" groups=["enemies"]]
 collision_layer = 2
 collision_mask = 13
 script = ExtResource( 2 )
-maxSpeed = 70.0
 canMoveOnAttack = false
 attackWindup = 0.5
-attackDistance = 50
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 rotation = 1.5708
 scale = Vector2( 0.7, 0.7 )
 frames = SubResource( 1 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+[node name="NavigationCollider" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
 
 [node name="NavigationAgent2D" type="NavigationAgent2D" parent="."]
 avoidance_enabled = true
 
+[node name="Area2D" type="Area2D" parent="."]
+collision_layer = 2
+collision_mask = 9
+
+[node name="WorldColliderArea" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource( 3 )
+
+[node name="AttackWindupTimer" type="Timer" parent="."]
+one_shot = true
+
+[node name="AttackCooldownTimer" type="Timer" parent="."]
+
 [connection signal="path_changed" from="NavigationAgent2D" to="." method="_on_NavigationAgent2D_path_changed"]
 [connection signal="velocity_computed" from="NavigationAgent2D" to="." method="_on_NavigationAgent2D_velocity_computed"]
+[connection signal="area_entered" from="Area2D" to="." method="_on_Area2D_area_entered"]
+[connection signal="timeout" from="AttackWindupTimer" to="." method="_on_AttackWindupTimer_timeout"]
+[connection signal="timeout" from="AttackCooldownTimer" to="." method="_on_AttackCooldownTimer_timeout"]

--- a/DefendTheKitchen/Enemy_Big.gd
+++ b/DefendTheKitchen/Enemy_Big.gd
@@ -1,0 +1,2 @@
+extends "res://Enemy.gd"
+

--- a/DefendTheKitchen/Enemy_Big.tscn
+++ b/DefendTheKitchen/Enemy_Big.tscn
@@ -1,0 +1,32 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://Enemy.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Enemy_Big.gd" type="Script" id=2]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 5.0
+
+[sub_resource type="CircleShape2D" id=2]
+radius = 35.0143
+
+[node name="Enemy_Big" instance=ExtResource( 1 )]
+script = ExtResource( 2 )
+maxSpeed = 50.0
+canMoveOnAttack = true
+attackCooldown = 0.6
+attackWindup = 0.4
+attackDistance = 60.0
+healthPoints = 3
+currentColor = Color( 0, 1, 0.156863, 1 )
+
+[node name="AnimatedSprite" parent="." index="0"]
+scale = Vector2( 1.1, 1.1 )
+
+[node name="NavigationCollider" parent="." index="1"]
+shape = SubResource( 1 )
+
+[node name="NavigationAgent2D" parent="." index="2"]
+navigation_layers = 4
+
+[node name="WorldColliderArea" parent="Area2D" index="0"]
+shape = SubResource( 2 )

--- a/DefendTheKitchen/Enemy_Fast.gd
+++ b/DefendTheKitchen/Enemy_Fast.gd
@@ -1,0 +1,2 @@
+extends "res://Enemy.gd"
+

--- a/DefendTheKitchen/Enemy_Fast.tscn
+++ b/DefendTheKitchen/Enemy_Fast.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://Enemy.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Enemy_Fast.gd" type="Script" id=2]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 21.0238
+
+[node name="Enemy_Fast" instance=ExtResource( 1 )]
+script = ExtResource( 2 )
+maxSpeed = 110.0
+canMoveOnAttack = true
+attackCooldown = 0.6
+attackWindup = 0.4
+attackDistance = 50.0
+currentColor = Color( 0.85098, 0, 1, 1 )
+
+[node name="NavigationCollider" parent="." index="1"]
+shape = SubResource( 1 )
+
+[node name="NavigationAgent2D" parent="." index="2"]
+navigation_layers = 2

--- a/DefendTheKitchen/Enemy_Normal.gd
+++ b/DefendTheKitchen/Enemy_Normal.gd
@@ -1,0 +1,2 @@
+extends "res://Enemy.gd"
+

--- a/DefendTheKitchen/Enemy_Normal.tscn
+++ b/DefendTheKitchen/Enemy_Normal.tscn
@@ -1,0 +1,27 @@
+[gd_scene load_steps=5 format=2]
+
+[ext_resource path="res://Enemy.tscn" type="PackedScene" id=1]
+[ext_resource path="res://Enemy_Normal.gd" type="Script" id=2]
+
+[sub_resource type="CircleShape2D" id=1]
+radius = 21.0238
+
+[sub_resource type="CircleShape2D" id=2]
+radius = 21.0
+
+[node name="Enemy_Normal" instance=ExtResource( 1 )]
+script = ExtResource( 2 )
+canMoveOnAttack = true
+attackCooldown = 0.6
+attackWindup = 0.4
+attackDistance = 50.0
+healthPoints = 2
+
+[node name="NavigationCollider" parent="." index="1"]
+shape = SubResource( 1 )
+
+[node name="NavigationAgent2D" parent="." index="2"]
+navigation_layers = 2
+
+[node name="CollisionShape2D" parent="Area2D" index="0"]
+shape = SubResource( 2 )

--- a/DefendTheKitchen/Food.gd
+++ b/DefendTheKitchen/Food.gd
@@ -18,3 +18,4 @@ func start():
 	
 func destroy():
 	queue_free();
+

--- a/DefendTheKitchen/Food.tscn
+++ b/DefendTheKitchen/Food.tscn
@@ -1,29 +1,25 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
-[ext_resource path="res://Art/pizza-64x64.png" type="Texture" id=1]
 [ext_resource path="res://Food.gd" type="Script" id=2]
 
-[sub_resource type="SpriteFrames" id=1]
-animations = [ {
-"frames": [ ExtResource( 1 ) ],
-"loop": true,
-"name": "default",
-"speed": 5.0
-} ]
-
 [sub_resource type="CircleShape2D" id=2]
-radius = 12.1655
+radius = 17.2627
 
-[node name="Food" type="KinematicBody2D"]
+[sub_resource type="CircleShape2D" id=3]
+radius = 17.0
+
+[node name="Food" type="KinematicBody2D" groups=["food"]]
 collision_layer = 8
-collision_mask = 6
+collision_mask = 18
 script = ExtResource( 2 )
 speed = 30000.0
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
-position = Vector2( -0.375, 0.375 )
-scale = Vector2( 0.0609375, 0.0609375 )
-frames = SubResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 2 )
+
+[node name="Area2D" type="Area2D" parent="."]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
+shape = SubResource( 3 )

--- a/DefendTheKitchen/Level.gd
+++ b/DefendTheKitchen/Level.gd
@@ -3,8 +3,27 @@ extends CanvasLayer
 
 signal level_changed(level_name)
 
-#handling enemy movement
-onready var line = $Line2D;
+class Wave:
+	var normalEnemyCount: int;
+	var fastEnemyCount: int;
+	var bigEnemyCount: int;
+	
+	
+	func _init(_normalEnemyCount:int = 1, _fastEnemyCount:int = 0, _bigEnemyCount:int = 0):
+		normalEnemyCount = _normalEnemyCount;
+		fastEnemyCount = _fastEnemyCount;
+		bigEnemyCount = _bigEnemyCount;
+
+var currentWave = 1;
+
+var normalEnemyPrefab = preload("res://Enemy_Normal.tscn");
+var fastEnemyPrefab = preload("res://Enemy_Fast.tscn");
+var bigEnemyPrefab = preload("res://Enemy_Big.tscn");
+var possibleSpawnPoints = [];
+
+var waves = [Wave.new(1,1,1), Wave.new(4,1,1)]
+var rng = RandomNumberGenerator.new()
+var aliveEnemies = 0;
 
 export (String) var level_name = "level"
 
@@ -18,6 +37,13 @@ func load_level_parameters(new_level_parameters: Dictionary):
 	level_parameters = new_level_parameters
 	$Player.nuxMode(level_parameters.nuxMode)
 	$GoldLabel.text = "Gold: " + str(level_parameters.gold)
+	
+	start_level();
+	
+func start_level():
+	rng.randomize();
+	possibleSpawnPoints = $EnemySpawnPoints.get_children();
+	spawn_wave();
 
 # Functionality for playing sounds when switching levels
 #func play_loaded_sound() -> void:
@@ -43,6 +69,74 @@ func _on_ChangeScene() -> void:
 	#gives 100 gold at the end of each level
 	set_gold(level_parameters.gold + 100)
 	emit_signal("level_changed", level_name)
+	
+	
+func spawn_wave():
+	# get the current wave
+	var wave = waves[currentWave - 1];
+	
+	# random starting spawn point
+	var spawnPointIndex = rng.randi_range(0,possibleSpawnPoints.size());
+	
+	# spawn the base enemies
+	for _n in range(wave.normalEnemyCount):
+		var enemy = normalEnemyPrefab.instance();
+		
+		
+		enemy.position = possibleSpawnPoints[spawnPointIndex % possibleSpawnPoints.size()].position;
+		
+		# connect enemy death signal so we can update enemy count
+		enemy.connect("died",self,"enemy_died");
+		$Navigation2D_Normal.call_deferred("add_child",enemy);
+		aliveEnemies += 1;
+		spawnPointIndex += 1;
+		
+		# slight delay between enemy spawns
+		yield(get_tree().create_timer(0.5),"timeout");
+		
+	# spawn the fast enemies
+	for _n in range(wave.fastEnemyCount):
+		var enemy = fastEnemyPrefab.instance();
+		
+		
+		enemy.position = possibleSpawnPoints[spawnPointIndex % possibleSpawnPoints.size()].position;
+		
+		# connect enemy death signal so we can update enemy count
+		enemy.connect("died",self,"enemy_died");
+		$Navigation2D_Normal.call_deferred("add_child",enemy);
+		aliveEnemies += 1;
+		spawnPointIndex += 1;
+		
+		# slight delay between enemy spawns
+		yield(get_tree().create_timer(0.5),"timeout");
+	
+	
+	# spawn the big enemies
+	for _n in range(wave.bigEnemyCount):
+		var enemy = bigEnemyPrefab.instance();
+		
+		
+		enemy.position = possibleSpawnPoints[spawnPointIndex % possibleSpawnPoints.size()].position;
+		
+		# connect enemy death signal so we can update enemy count
+		enemy.connect("died",self,"enemy_died");
+		$Navigation2D_Wide.call_deferred("add_child",enemy);
+		aliveEnemies += 1;
+		spawnPointIndex += 1;
+		
+		# slight delay between enemy spawns
+		yield(get_tree().create_timer(0.5),"timeout");
 
-func _on_Enemy_pathChanged(path):
-	line.points = path;
+func enemy_died(_enemy):
+	aliveEnemies -= 1;
+	print("Enemy Died!!!");
+	if aliveEnemies <= 0:
+		complete_wave();
+		
+func complete_wave():
+	print("Completed wave");
+	currentWave += 1;
+	if currentWave > waves.size():
+		print("You won!");
+	else:	
+		spawn_wave();

--- a/DefendTheKitchen/Level1.tscn
+++ b/DefendTheKitchen/Level1.tscn
@@ -1,32 +1,49 @@
-[gd_scene load_steps=6 format=2]
+[gd_scene load_steps=7 format=2]
 
 [ext_resource path="res://Level.gd" type="Script" id=1]
 [ext_resource path="res://TileMap.tscn" type="PackedScene" id=2]
 [ext_resource path="res://Player.tscn" type="PackedScene" id=3]
-[ext_resource path="res://Enemy.tscn" type="PackedScene" id=4]
 [ext_resource path="res://Stove.tscn" type="PackedScene" id=5]
+
+[sub_resource type="NavigationPolygon" id=1]
+vertices = PoolVector2Array( 848, 464, 944, 560, 752, 560, 656, 528, 752, 464, 848, 336, 944, 80, 848, 368, 848, 240, 1144, -160, 1152, 888, 1040, 656, 1040, -16, -272, -160, 752, -16, 656, 368, 752, 368, -280, 888, 752, 656, 496, 368, 848, 208, 848, 80, 752, 208, 752, 240, 496, 528, 752, 336 )
+polygons = [ PoolIntArray( 0, 1, 2, 3, 4 ), PoolIntArray( 5, 6, 1, 7 ), PoolIntArray( 6, 5, 8 ), PoolIntArray( 9, 10, 11, 12 ), PoolIntArray( 13, 9, 12, 14 ), PoolIntArray( 4, 3, 15, 16 ), PoolIntArray( 11, 10, 17, 18 ), PoolIntArray( 17, 13, 14, 19 ), PoolIntArray( 20, 21, 6 ), PoolIntArray( 20, 6, 8 ), PoolIntArray( 22, 20, 8, 23 ), PoolIntArray( 3, 2, 18, 17, 24 ), PoolIntArray( 19, 24, 17 ), PoolIntArray( 19, 14, 22, 15 ), PoolIntArray( 15, 22, 23 ), PoolIntArray( 15, 23, 25 ), PoolIntArray( 16, 15, 25, 5 ), PoolIntArray( 7, 16, 5 ), PoolIntArray( 7, 1, 0 ) ]
+outlines = [ PoolVector2Array( -272, -160, 1144, -160, 1152, 888, -280, 888 ), PoolVector2Array( 496, 368, 656, 368, 656, 528, 496, 528 ), PoolVector2Array( 752, 208, 848, 208, 848, 80, 944, 80, 944, 560, 752, 560, 752, 656, 1040, 656, 1040, -16, 752, -16 ), PoolVector2Array( 752, 240, 848, 240, 848, 336, 752, 336 ), PoolVector2Array( 752, 368, 848, 368, 848, 464, 752, 464 ) ]
+
+[sub_resource type="NavigationPolygon" id=2]
+vertices = PoolVector2Array( 856, 472, 936, 552, 744, 552, 664, 536, 744, 472, 856, 344, 936, 88, 856, 360, 856, 232, 1144, -160, 1152, 888, 1040, 656, 1040, -16, 664, 360, 744, 360, -272, -160, 744, -16, -280, 888, 744, 656, 488, 360, 856, 216, 856, 88, 744, 216, 744, 232, 488, 536, 744, 344 )
+polygons = [ PoolIntArray( 0, 1, 2, 3, 4 ), PoolIntArray( 5, 6, 1, 7 ), PoolIntArray( 6, 5, 8 ), PoolIntArray( 9, 10, 11, 12 ), PoolIntArray( 4, 3, 13, 14 ), PoolIntArray( 15, 9, 12, 16 ), PoolIntArray( 11, 10, 17, 18 ), PoolIntArray( 17, 15, 16, 19 ), PoolIntArray( 20, 21, 6 ), PoolIntArray( 20, 6, 8 ), PoolIntArray( 22, 20, 8, 23 ), PoolIntArray( 3, 2, 18, 17, 24 ), PoolIntArray( 19, 24, 17 ), PoolIntArray( 19, 16, 22, 13 ), PoolIntArray( 13, 22, 23 ), PoolIntArray( 13, 23, 25 ), PoolIntArray( 14, 13, 25, 5 ), PoolIntArray( 7, 14, 5 ), PoolIntArray( 7, 1, 0 ) ]
+outlines = [ PoolVector2Array( -272, -160, 1144, -160, 1152, 888, -280, 888 ), PoolVector2Array( 488, 360, 664, 360, 664, 536, 488, 536 ), PoolVector2Array( 744, 216, 856, 216, 856, 88, 936, 88, 936, 552, 744, 552, 744, 656, 1040, 656, 1040, -16, 744, -16 ), PoolVector2Array( 744, 232, 856, 232, 856, 344, 744, 344 ), PoolVector2Array( 744, 360, 856, 360, 856, 472, 744, 472 ) ]
 
 [node name="Level1" type="CanvasLayer"]
 script = ExtResource( 1 )
 level_name = "level1"
 
 [node name="TileMap" parent="." instance=ExtResource( 2 )]
-bake_navigation = true
+show_collision = false
+collision_layer = 16
+collision_mask = 9
 tile_data = PoolIntArray( 65535, 3, 0, 0, 3, 0, 1, 3, 0, 2, 3, 0, 3, 3, 0, 4, 3, 0, 5, 3, 0, 6, 3, 0, 7, 3, 0, 8, 3, 0, 9, 3, 0, 10, 3, 0, 11, 3, 0, 12, 2, 0, 13, 2, 0, 14, 2, 0, 15, 2, 0, 131071, 3, 0, 65536, 3, 0, 65537, 3, 0, 65538, 3, 0, 65539, 3, 0, 65540, 3, 0, 65541, 3, 0, 65542, 3, 0, 65543, 3, 0, 65544, 3, 0, 65545, 3, 0, 65546, 3, 0, 65547, 3, 0, 65548, 2, 0, 65549, 3, 0, 65550, 3, 0, 65551, 2, 0, 196607, 3, 0, 131072, 3, 0, 131073, 3, 0, 131074, 3, 0, 131075, 3, 0, 131076, 3, 0, 131077, 3, 0, 131078, 3, 0, 131079, 3, 0, 131080, 3, 0, 131081, 3, 0, 131082, 3, 0, 131083, 3, 0, 131084, 2, 0, 131085, 3, 0, 131086, 3, 0, 131087, 2, 0, 262143, 3, 0, 196608, 3, 0, 196609, 3, 0, 196610, 3, 0, 196611, 3, 0, 196612, 3, 0, 196613, 3, 0, 196614, 3, 0, 196615, 3, 0, 196616, 3, 0, 196617, 3, 0, 196618, 3, 0, 196619, 3, 0, 196620, 3, 0, 196621, 3, 0, 196622, 3, 0, 196623, 2, 0, 327679, 3, 0, 262144, 3, 0, 262145, 3, 0, 262146, 3, 0, 262147, 3, 0, 262148, 3, 0, 262149, 3, 0, 262150, 3, 0, 262151, 3, 0, 262152, 3, 0, 262153, 3, 0, 262154, 3, 0, 262155, 3, 0, 262156, 2, 0, 262157, 3, 0, 262158, 3, 0, 393215, 3, 0, 327680, 3, 0, 327681, 3, 0, 327682, 3, 0, 327683, 3, 0, 327684, 3, 0, 327685, 3, 0, 327686, 3, 0, 327687, 3, 0, 327688, 3, 0, 327689, 3, 0, 327690, 3, 0, 327691, 3, 0, 327692, 3, 0, 327693, 3, 0, 327694, -1610612733, 0, 327695, 2, 0, 458751, 3, 0, 393216, 3, 0, 393217, 3, 0, 393218, 3, 0, 393219, 3, 0, 393220, 3, 0, 393221, 3, 0, 393222, 3, 0, 393223, 3, 0, 393224, 2, 0, 393225, 2, 0, 393226, 3, 0, 393227, 3, 0, 393228, 2, 0, 393229, 3, 0, 393230, -1610612733, 0, 393231, 2, 0, 524287, 3, 0, 458752, 3, 0, 458753, 3, 0, 458754, 3, 0, 458755, 3, 0, 458756, 3, 0, 458757, 3, 0, 458758, 3, 0, 458759, 3, 0, 458760, 2, 0, 458761, 2, 0, 458762, 3, 0, 458763, 3, 0, 458764, 3, 0, 458765, 3, 0, 458766, 3, 0, 458767, 2, 0, 589823, 3, 0, 524288, 3, 0, 524289, 3, 0, 524290, 3, 0, 524291, 3, 0, 524292, 3, 0, 524293, 3, 0, 524294, 3, 0, 524295, 3, 0, 524296, 3, 0, 524297, 3, 0, 524298, 3, 0, 524299, 3, 0, 524300, 3, 0, 524301, 3, 0, 524302, 3, 0, 524303, 2, 0, 655359, 3, 0, 589824, 3, 0, 589825, 3, 0, 589826, 3, 0, 589827, 3, 0, 589828, 3, 0, 589829, 3, 0, 589830, 3, 0, 589831, 3, 0, 589832, 3, 0, 589833, 3, 0, 589834, 3, 0, 589835, 3, 0, 589836, 2, 0, 589837, 2, 0, 589838, 2, 0, 589839, 2, 0 )
+
+[node name="Navigation2D_Normal" type="Navigation2D" parent="."]
+navigation_layers = 2
+
+[node name="NavigationPolygonInstance" type="NavigationPolygonInstance" parent="Navigation2D_Normal"]
+navpoly = SubResource( 1 )
+navigation_layers = 2
+
+[node name="Navigation2D_Wide" type="Navigation2D" parent="."]
+navigation_layers = 4
+
+[node name="NavigationPolygonInstance" type="NavigationPolygonInstance" parent="Navigation2D_Wide"]
+navpoly = SubResource( 2 )
+navigation_layers = 4
 
 [node name="Player" parent="." instance=ExtResource( 3 )]
 position = Vector2( 903, 303 )
 
-[node name="Line2D" type="Line2D" parent="."]
-visible = false
-width = 5.0
-default_color = Color( 0.886275, 0.886275, 0.886275, 1 )
-
 [node name="Stove" parent="." instance=ExtResource( 5 )]
 position = Vector2( 992, 284 )
-
-[node name="Enemy" parent="." instance=ExtResource( 4 )]
-position = Vector2( 102, 435 )
 
 [node name="GoldLabel" type="Label" parent="."]
 margin_left = 631.0
@@ -37,5 +54,42 @@ text = "Gold: "
 valign = 1
 uppercase = true
 
+[node name="EnemySpawnPoints" type="Node2D" parent="."]
+
+[node name="EnemySpawnPoint" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -64, 0 )
+
+[node name="EnemySpawnPoint2" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -64, 640 )
+
+[node name="EnemySpawnPoint3" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -200, 504 )
+
+[node name="EnemySpawnPoint4" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -192, 168 )
+
+[node name="EnemySpawnPoint5" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -120, 272 )
+
+[node name="EnemySpawnPoint6" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -128, 416 )
+
+[node name="EnemySpawnPoint7" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( 136, 720 )
+
+[node name="EnemySpawnPoint8" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( 136, -64 )
+
+[node name="EnemySpawnPoint9" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -152, -32 )
+
+[node name="EnemySpawnPoint10" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( -160, 696 )
+
+[node name="EnemySpawnPoint11" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( 32, 736 )
+
+[node name="EnemySpawnPoint12" type="Node2D" parent="EnemySpawnPoints"]
+position = Vector2( 40, -64 )
+
 [connection signal="pizza_added" from="Stove" to="Player" method="_on_Stove_pizza_added"]
-[connection signal="pathChanged" from="Enemy" to="." method="_on_Enemy_pathChanged"]

--- a/DefendTheKitchen/Main.gd
+++ b/DefendTheKitchen/Main.gd
@@ -1,6 +1,3 @@
 extends Node
 
-onready var line = $Line2D;
 
-func _on_Enemy_pathChanged(path):
-	line.points = path;

--- a/DefendTheKitchen/Pizza.gd
+++ b/DefendTheKitchen/Pizza.gd
@@ -9,8 +9,17 @@ func _physics_process(_delta):
 		var collision := get_slide_collision(index);
 		var body := collision.collider;
 		if body.is_in_group("enemies"):
-			body.takeDamage(1.0);
-			
-		
+			HitEnemy(body);
 		destroy();
 		break;
+
+
+func _on_Area2D_area_entered(area):
+	if area.get_parent().is_in_group("enemies"):
+		HitEnemy(area.get_parent());
+	destroy();
+	
+
+func HitEnemy(enemy):
+	enemy.takeDamage(1.0);
+	destroy();

--- a/DefendTheKitchen/Pizza.tscn
+++ b/DefendTheKitchen/Pizza.tscn
@@ -1,19 +1,27 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://Food.tscn" type="PackedScene" id=1]
 [ext_resource path="res://Pizza.gd" type="Script" id=2]
+[ext_resource path="res://Art/pizza-64x64.png" type="Texture" id=3]
 
-[sub_resource type="CircleShape2D" id=1]
-radius = 26.0768
+[sub_resource type="SpriteFrames" id=1]
+animations = [ {
+"frames": [ ExtResource( 3 ) ],
+"loop": true,
+"name": "default",
+"speed": 5.0
+} ]
+
+[sub_resource type="CircleShape2D" id=2]
+radius = 17.0
 
 [node name="Pizza" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
 speed = 200.0
 
 [node name="AnimatedSprite" parent="." index="0"]
-position = Vector2( 0, 0 )
-scale = Vector2( 1, 1 )
+scale = Vector2( 0.7, 0.7 )
+frames = SubResource( 1 )
 
-[node name="CollisionShape2D" parent="." index="1"]
-position = Vector2( 0, -1 )
-shape = SubResource( 1 )
+[node name="CollisionShape2D" parent="Area2D" index="0"]
+shape = SubResource( 2 )

--- a/DefendTheKitchen/Player.gd
+++ b/DefendTheKitchen/Player.gd
@@ -88,7 +88,8 @@ func ThrowFood():
 		var b = foods["pizza"].instance();
 		b.direction = aimDirection;
 		owner.add_child(b);
-		b.global_position = global_position;
+		# spawn food in front of player
+		b.global_position = global_position + aimDirection * 30.0;
 		food_count["pizza"] -= 1
 		
 		emit_signal("update_inventory", food_count)

--- a/DefendTheKitchen/Stove.tscn
+++ b/DefendTheKitchen/Stove.tscn
@@ -36,7 +36,6 @@ frames = SubResource( 1 )
 flip_v = true
 
 [node name="StoveTimer" type="Timer" parent="."]
-wait_time = 2.0
 one_shot = true
 
 [connection signal="body_entered" from="Area2D" to="." method="_on_Area2D_body_entered"]

--- a/DefendTheKitchen/project.godot
+++ b/DefendTheKitchen/project.godot
@@ -14,13 +14,6 @@ config/name="DefendTheKitchen"
 run/main_scene="res://Main.tscn"
 config/icon="res://Art/icon.png"
 
-[autoload]
-
-PluginSettings="*res://addons/github-integration/scripts/PluginSettings.gd"
-IconLoaderGithub="*res://addons/github-integration/scripts/IconLoaderGithub.gd"
-UserData="*res://addons/github-integration/scripts/user_data.gd"
-RestHandler="*res://addons/github-integration/scenes/RestHandler.tscn"
-
 [display]
 
 window/size/height=740
@@ -84,6 +77,10 @@ pause={
 2d_physics/layer_2="Enemy"
 2d_physics/layer_3="Wall"
 2d_physics/layer_4="FoodProjectile"
+2d_physics/layer_5="Tilemap"
+2d_navigation/layer_2="normal"
+2d_navigation/layer_3="wide"
+2d_navigation/layer_4="tight"
 
 [physics]
 


### PR DESCRIPTION
Added different enemy types (enemy_normal, enemy_fast, enemy_big). Added wave system within level.gd (enemy spawn points, number and type of enemies per wave). Updated collisions for enemies and food. Switched enemy attack timers to be actual timers instead of yield() calls to avoid error. Added food to "food" group.

IMPORTANT
Enemies no longer use the tilemap for navigation. The reasoning for this is that navigation agents don't account for their size when creating a path so the enemies would create a path right around a tile map corner which would cause them to get stuck on the wall. The workaround is to use a navigation polygon to draw the navigable areas. This allows for buffer space between obstacles and the enemies' path. In order for there to be bigger enemies, the path around obstacles needs to be wider so that the enemies don't collide with the obstacles. Each enemy now has a navigation collider (only used for navigation purposes) and a collider used for food collisions. There is a separate navigation polygon used by the bigger enemies.  