### PR TITLE
fixed collision issue

### DIFF
--- a/DefendTheKitchen/Enemy.tscn
+++ b/DefendTheKitchen/Enemy.tscn
@@ -12,7 +12,7 @@ animations = [ {
 } ]
 
 [sub_resource type="CircleShape2D" id=2]
-radius = 21.0238
+radius = 17.0
 
 [sub_resource type="CircleShape2D" id=3]
 radius = 21.095

--- a/DefendTheKitchen/Enemy_Fast.tscn
+++ b/DefendTheKitchen/Enemy_Fast.tscn
@@ -4,7 +4,7 @@
 [ext_resource path="res://Enemy_Fast.gd" type="Script" id=2]
 
 [sub_resource type="CircleShape2D" id=1]
-radius = 21.0238
+radius = 16.0
 
 [node name="Enemy_Fast" instance=ExtResource( 1 )]
 script = ExtResource( 2 )

--- a/DefendTheKitchen/Food.tscn
+++ b/DefendTheKitchen/Food.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://Food.gd" type="Script" id=2]
 
 [sub_resource type="CircleShape2D" id=2]
-radius = 17.2627
+radius = 11.0
 
 [sub_resource type="CircleShape2D" id=3]
 radius = 17.0

--- a/DefendTheKitchen/Icecream.gd
+++ b/DefendTheKitchen/Icecream.gd
@@ -8,17 +8,8 @@ func _physics_process(_delta):
 	for index in get_slide_count():
 		var collision := get_slide_collision(index);
 		var body := collision.collider;
-		if body.is_in_group("enemies"):
-			HitEnemy(body);
 		destroy();
 		break;
-
-
-func _on_Area2D_area_entered(area):
-	if area.get_parent().is_in_group("enemies"):
-		HitEnemy(area.get_parent());
-	destroy();
-	
 
 func HitEnemy(enemy):
 	enemy.activateStatusEffect("frost")

--- a/DefendTheKitchen/Icecream.tscn
+++ b/DefendTheKitchen/Icecream.tscn
@@ -13,8 +13,7 @@ animations = [ {
 } ]
 
 [sub_resource type="CapsuleShape2D" id=2]
-radius = 15.0
-height = 28.0
+height = 16.0
 
 [sub_resource type="CapsuleShape2D" id=3]
 radius = 16.0

--- a/DefendTheKitchen/Pizza.gd
+++ b/DefendTheKitchen/Pizza.gd
@@ -8,16 +8,8 @@ func _physics_process(_delta):
 	for index in get_slide_count():
 		var collision := get_slide_collision(index);
 		var body := collision.collider;
-		if body.is_in_group("enemies"):
-			HitEnemy(body);
 		destroy();
 		break;
-
-
-func _on_Area2D_area_entered(area):
-	if area.get_parent().is_in_group("enemies"):
-		HitEnemy(area.get_parent());
-	destroy();
 	
 
 func HitEnemy(enemy):


### PR DESCRIPTION
Fixed issue with double collisions happening between food and enemies which caused a single pizza to sometimes kill a normal full health enemy. Collisions are now only checked within the enemy script which calls the HitEnemy function on whatever food hit it.