### PR TITLE
Fixed pizza crash bug and upgrade throw food bug

### DIFF
--- a/DefendTheKitchen/Enemy.gd
+++ b/DefendTheKitchen/Enemy.gd
@@ -77,7 +77,7 @@ func _physics_process(_delta):
 func CalculateMovement(_delta):
 	if player != null and canMove:
 		# move towards the player
-		if (targettedFood != null):
+		if (targettedFood != null and is_instance_valid(targettedFood)):
 			navigationAgent.set_target_location(targettedFood.global_position);
 		else:
 			navigationAgent.set_target_location(player.global_position);

--- a/DefendTheKitchen/Player.gd
+++ b/DefendTheKitchen/Player.gd
@@ -14,6 +14,7 @@ export var gold = 0;
 var currentEquip = 1;
 var levelNode;
 var canThrowFood = true;
+var mouseClickEnabled = true;
 
 # Stuff for the upgrade buttons that appear over appliances
 const upgradeButtonResource = preload("res://UpgradeButton.tscn");
@@ -90,8 +91,16 @@ func GetInput():
 		$AnimatedSprite.play("default");
 	aimDirection = (get_global_mouse_position() - global_position).normalized();
 	$AnimatedSprite.rotation = aimDirection.angle() + 90;
+	
 	if Input.is_action_just_pressed("mouse_click"):
-		ThrowFood();
+		
+		# mouseClickEnabled is set to false when the player clicks the
+		# upgrade button (see UpgradeButton.gd). This prevents the player from 
+		# shooting food when interacting with gui elements.
+		if mouseClickEnabled:
+			ThrowFood();
+		else:
+			mouseClickEnabled = true;
 	if Input.is_action_just_pressed("pause"):
 		get_tree().paused = !get_tree().paused;
 	if Input.is_action_just_pressed("Equip1"):

--- a/DefendTheKitchen/UpgradeButton.gd
+++ b/DefendTheKitchen/UpgradeButton.gd
@@ -23,6 +23,8 @@ func updateButtonText(val):
 # was valid and emits a signal if it was
 func _on_Button_pressed():
 	
+	player.mouseClickEnabled = false;
+	
 	if (player.gold >= appliance.upgradeCost):
 		
 		emit_signal("playerPressedUpgrade");


### PR DESCRIPTION
Enemy script now checks for valid instance and null (should prevent crash from invalid instance). Player can no longer throw food while pressing the upgrade button.