### PR TITLE
updated settings

### DIFF
--- a/DefendTheKitchen/Enemy.gd
+++ b/DefendTheKitchen/Enemy.gd
@@ -153,8 +153,15 @@ func _on_Area2D_area_entered(area):
 func activateStatusEffect(effect):
 	match effect:
 		"frost": #reduce the speed from frost
+			
+			# check if we have already been frosted
+			if $StatusEffectTimer.time_left > 0:
+				maxSpeed -= statusEffect.frost;
+				maxSpeed = max(0.0,maxSpeed);
+				return;
 			origSpeed = maxSpeed #assign temp variable for holding old speed
 			maxSpeed -= statusEffect.frost
+			maxSpeed = max(0.0,maxSpeed);
 			$StatusEffectTimer.start()
 
 func _on_StatusEffectTimer_timeout():

--- a/DefendTheKitchen/Enemy.tscn
+++ b/DefendTheKitchen/Enemy.tscn
@@ -49,7 +49,7 @@ one_shot = true
 [node name="AttackCooldownTimer" type="Timer" parent="."]
 
 [node name="StatusEffectTimer" type="Timer" parent="."]
-wait_time = 3.0
+wait_time = 4.0
 one_shot = true
 
 [node name="HealthLabel" type="Label" parent="."]

--- a/DefendTheKitchen/Enemy_Big.tscn
+++ b/DefendTheKitchen/Enemy_Big.tscn
@@ -11,10 +11,10 @@ radius = 35.0143
 
 [node name="Enemy_Big" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
-maxSpeed = 50.0
+maxSpeed = 80.0
 canMoveOnAttack = true
 attackCooldown = 0.6
-attackWindup = 0.4
+attackWindup = 0.2
 attackDistance = 60.0
 healthPoints = 5
 currentColor = Color( 0, 1, 0.156863, 1 )

--- a/DefendTheKitchen/Enemy_Boss.tscn
+++ b/DefendTheKitchen/Enemy_Boss.tscn
@@ -20,10 +20,10 @@ radius = 53.0094
 
 [node name="Enemy_Boss" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
-maxSpeed = 130.0
+maxSpeed = 140.0
 canMoveOnAttack = true
 attackCooldown = 0.6
-attackWindup = 0.4
+attackWindup = 0.2
 attackDistance = 60.0
 healthPoints = 5
 numberOfMinions = 4

--- a/DefendTheKitchen/Enemy_Fast.tscn
+++ b/DefendTheKitchen/Enemy_Fast.tscn
@@ -8,10 +8,10 @@ radius = 16.0
 
 [node name="Enemy_Fast" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
-maxSpeed = 120.0
+maxSpeed = 140.0
 canMoveOnAttack = true
 attackCooldown = 0.6
-attackWindup = 0.4
+attackWindup = 0.2
 attackDistance = 50.0
 currentColor = Color( 0.85098, 0, 1, 1 )
 

--- a/DefendTheKitchen/Enemy_Normal.tscn
+++ b/DefendTheKitchen/Enemy_Normal.tscn
@@ -8,9 +8,10 @@ radius = 19.0263
 
 [node name="Enemy_Normal" instance=ExtResource( 1 )]
 script = ExtResource( 2 )
+maxSpeed = 100.0
 canMoveOnAttack = true
 attackCooldown = 0.6
-attackWindup = 0.4
+attackWindup = 0.2
 attackDistance = 50.0
 healthPoints = 3
 

--- a/DefendTheKitchen/IcecreamMachine.gd
+++ b/DefendTheKitchen/IcecreamMachine.gd
@@ -72,4 +72,4 @@ func _upgrade():
 	self.upgradeCost += 10;
 	emit_signal("update_upgrade", upgradeCost);
 	
-	$IcecreamTimer.wait_time = 1;
+	$IcecreamTimer.wait_time *= 0.75;

--- a/DefendTheKitchen/IcecreamMachine.tscn
+++ b/DefendTheKitchen/IcecreamMachine.tscn
@@ -25,6 +25,7 @@ animations = [ {
 [node name="IcecreamMachine" type="StaticBody2D"]
 collision_layer = 0
 script = ExtResource( 2 )
+upgradeCost = 20
 
 [node name="Area2D" type="Area2D" parent="."]
 
@@ -43,7 +44,7 @@ frames = SubResource( 1 )
 flip_v = true
 
 [node name="IcecreamTimer" type="Timer" parent="."]
-wait_time = 2.0
+wait_time = 3.0
 one_shot = true
 
 [node name="ProgressBar" type="TextureProgress" parent="."]

--- a/DefendTheKitchen/Level.gd
+++ b/DefendTheKitchen/Level.gd
@@ -27,10 +27,10 @@ var bigEnemyPrefab = preload("res://Enemy_Big.tscn");
 var bossEnemyPrefab = preload("res://Enemy_Boss.tscn");
 var possibleSpawnPoints = [];
 export var canThrowFoodOutsideKitchen = false;
-var waves = [Wave.new(3,0,0), Wave.new(3,2,0),Wave.new(5,3,1), Wave.new(5,2,2),Wave.new(4,4,2,1)]
+var waves = [Wave.new(3,0,0), Wave.new(3,2,0),Wave.new(5,3,1), Wave.new(5,2,2), Wave.new(6,3,2),Wave.new(7,4,2),Wave.new(5,4,2,1)]
 var rng = RandomNumberGenerator.new()
 var aliveEnemies = 0;
-var waveGold = 20
+var waveGold = 15
 var enemySoundPlayed = false
 
 var isBetweenWaves = false;
@@ -164,9 +164,7 @@ func complete_wave():
 	isBetweenWaves = true;
 	$Player.setGold($Player.getGold() + waveGold) #Adding reward gold to players inventory
 	print("Added " + str(waveGold) + " Gold")
-	
-	# remove all food that is on the floor
-	get_tree().call_group("food","queue_free");
+	$Player.canThrowFood = false;
 	
 	if currentWave >= waves.size():
 		print("You won!");
@@ -183,6 +181,7 @@ func _on_HUD_nextWave():
 	emit_signal("start_wave", currentWave)
 	isBetweenWaves = false;
 	spawn_wave();
+	$Player.canThrowFood = true;
 
 
 func _on_KitchenArea2D_body_entered(body):

--- a/DefendTheKitchen/Level1.tscn
+++ b/DefendTheKitchen/Level1.tscn
@@ -11,20 +11,21 @@
 [ext_resource path="res://Music/Wilhelm_Scream.ogg" type="AudioStream" id=9]
 
 [sub_resource type="NavigationPolygon" id=1]
-vertices = PoolVector2Array( 1488, 336, 1488, 496, 1392, 496, 656, 464, 1392, 336, 1488, 656, 1840, 80, 1840, 944, 1488, 752, 1488, 176, 1392, 80, 1392, 176, 1104, 112, 1104, 272, 976, 784, 976, 624, 1392, 752, 1392, 1160, -360, 1160, 816, 784, -344, -168, 496, 464, 944, 272, 656, 304, 1488, 944, 1392, 656, 816, 624, 1392, -168, 1392, -24, 944, 112, 496, 304 )
-polygons = [ PoolIntArray( 0, 1, 2, 3, 4 ), PoolIntArray( 5, 6, 7, 8 ), PoolIntArray( 6, 5, 1 ), PoolIntArray( 0, 6, 1 ), PoolIntArray( 6, 0, 9 ), PoolIntArray( 10, 6, 9, 11, 12 ), PoolIntArray( 13, 11, 4, 3 ), PoolIntArray( 11, 13, 12 ), PoolIntArray( 14, 15, 16, 17 ), PoolIntArray( 14, 17, 18, 19 ), PoolIntArray( 19, 18, 20, 21 ), PoolIntArray( 22, 13, 3, 23 ), PoolIntArray( 7, 24, 8 ), PoolIntArray( 25, 5, 8, 16 ), PoolIntArray( 25, 16, 15 ), PoolIntArray( 2, 25, 15, 3 ), PoolIntArray( 3, 15, 26 ), PoolIntArray( 20, 27, 28 ), PoolIntArray( 20, 28, 10, 12, 29 ), PoolIntArray( 20, 29, 22, 23, 30 ), PoolIntArray( 20, 30, 21 ), PoolIntArray( 19, 21, 3, 26 ) ]
-outlines = [ PoolVector2Array( 1392, -24, 1392, 80, 1840, 80, 1840, 944, 1488, 944, 1488, 752, 1392, 752, 1392, 1160, -360, 1160, -344, -168, 1392, -168 ), PoolVector2Array( 1392, 176, 1488, 176, 1488, 336, 1392, 336 ), PoolVector2Array( 1392, 496, 1488, 496, 1488, 656, 1392, 656 ), PoolVector2Array( 944, 112, 1104, 112, 1104, 272, 944, 272 ), PoolVector2Array( 816, 624, 976, 624, 976, 784, 816, 784 ), PoolVector2Array( 496, 304, 656, 304, 656, 464, 496, 464 ) ]
+vertices = PoolVector2Array( 1488, 656, 1760, 576, 1840, 576, 1840, 944, 1600, 872, 1488, 752, 1768, 152, 1840, 160, 1840, 432, 1760, 432, 1488, 336, 1488, 176, 656, 464, 1392, 336, 1488, 496, 1392, 496, 1104, 272, 1392, 176, 944, 272, 656, 304, 1104, 112, 1392, 80, 1752, 80, 976, 784, 976, 624, 1392, 752, 1392, 1160, -360, 1160, 816, 784, -344, -168, 496, 464, 1392, -168, 1392, -24, 1392, 656, 944, 112, 496, 304, 1488, 852.092, 1614.92, 944, 816, 624 )
+polygons = [ PoolIntArray( 0, 1, 2, 3, 4, 5 ), PoolIntArray( 6, 7, 8, 9, 10, 11 ), PoolIntArray( 12, 13, 10, 9, 14, 15 ), PoolIntArray( 13, 12, 16, 17 ), PoolIntArray( 18, 16, 12, 19 ), PoolIntArray( 1, 0, 14, 9 ), PoolIntArray( 17, 16, 20, 21 ), PoolIntArray( 21, 22, 6, 11, 17 ), PoolIntArray( 23, 24, 25, 26 ), PoolIntArray( 23, 26, 27, 28 ), PoolIntArray( 28, 27, 29, 30 ), PoolIntArray( 29, 31, 32 ), PoolIntArray( 12, 15, 33, 24 ), PoolIntArray( 29, 32, 21, 20, 34 ), PoolIntArray( 29, 34, 18, 19, 35 ), PoolIntArray( 4, 36, 5 ), PoolIntArray( 3, 37, 4 ), PoolIntArray( 33, 0, 5, 25 ), PoolIntArray( 33, 25, 24 ), PoolIntArray( 12, 24, 38 ), PoolIntArray( 29, 35, 30 ), PoolIntArray( 28, 30, 12, 38 ) ]
+outlines = [ PoolVector2Array( 1392, -24, 1392, 80, 1752, 80, 1768, 152, 1840, 160, 1840, 432, 1760, 432, 1760, 576, 1840, 576, 1840, 944, 1614.92, 944, 1600, 872, 1488, 852.092, 1488, 752, 1392, 752, 1392, 1160, -360, 1160, -344, -168, 1392, -168 ), PoolVector2Array( 1392, 176, 1488, 176, 1488, 336, 1392, 336 ), PoolVector2Array( 1392, 496, 1488, 496, 1488, 656, 1392, 656 ), PoolVector2Array( 944, 112, 1104, 112, 1104, 272, 944, 272 ), PoolVector2Array( 816, 624, 976, 624, 976, 784, 816, 784 ), PoolVector2Array( 496, 304, 656, 304, 656, 464, 496, 464 ) ]
 
 [sub_resource type="NavigationPolygon" id=2]
-vertices = PoolVector2Array( 1504, 352, 1504, 160, 1824, 96, 1824, 928, 1376, 96, 1376, 160, 1376, 352, 1120, 288, 1120, 96, 992, 800, 992, 608, 1376, 736, 1376, 1160, -360, 1160, 800, 800, -344, -168, 480, 480, 1392, -168, 1384, -24, 672, 480, 672, 288, 1376, 480, 1376, 672, 1504, 928, 1504, 736, 1504, 672, 800, 608, 928, 96, 928, 288, 1504, 480, 480, 288 )
-polygons = [ PoolIntArray( 0, 1, 2, 3 ), PoolIntArray( 4, 2, 1, 5 ), PoolIntArray( 5, 6, 7, 8 ), PoolIntArray( 4, 5, 8 ), PoolIntArray( 9, 10, 11, 12 ), PoolIntArray( 9, 12, 13, 14 ), PoolIntArray( 14, 13, 15, 16 ), PoolIntArray( 15, 17, 18, 4, 8 ), PoolIntArray( 19, 20, 21, 22, 10 ), PoolIntArray( 3, 23, 24 ), PoolIntArray( 25, 3, 24 ), PoolIntArray( 22, 25, 24, 11 ), PoolIntArray( 22, 11, 10 ), PoolIntArray( 19, 10, 26, 16 ), PoolIntArray( 15, 8, 27 ), PoolIntArray( 15, 27, 28, 20 ), PoolIntArray( 3, 25, 29 ), PoolIntArray( 0, 3, 29 ), PoolIntArray( 6, 0, 29, 21 ), PoolIntArray( 6, 21, 20, 28 ), PoolIntArray( 16, 26, 14 ), PoolIntArray( 30, 16, 15 ), PoolIntArray( 20, 30, 15 ), PoolIntArray( 6, 28, 7 ) ]
-outlines = [ PoolVector2Array( 1384, -24, 1376, 96, 1824, 96, 1824, 928, 1504, 928, 1504, 736, 1376, 736, 1376, 1160, -360, 1160, -344, -168, 1392, -168 ), PoolVector2Array( 1376, 160, 1504, 160, 1504, 352, 1376, 352 ), PoolVector2Array( 1376, 480, 1504, 480, 1504, 672, 1376, 672 ), PoolVector2Array( 928, 96, 1120, 96, 1120, 288, 928, 288 ), PoolVector2Array( 800, 608, 992, 608, 992, 800, 800, 800 ), PoolVector2Array( 480, 288, 672, 288, 672, 480, 480, 480 ) ]
+vertices = PoolVector2Array( 1768, 160, 1832, 168, 1824, 416, 1752, 424, 1504, 352, 1504, 160, 1504, 672, 1752, 576, 1824, 584, 1824, 928, 1608, 864, 1504, 736, 1504, 480, 1376, 352, 1376, 480, 1376, 160, 1120, 288, 1120, 96, 1752, 88, 1376, 96, 992, 800, 992, 608, 1376, 736, 1376, 1160, -360, 1160, 800, 800, -344, -168, 480, 480, 1392, -168, 1384, -24, 672, 480, 928, 288, 672, 288, 928, 96, 1376, 672, 1504, 864, 1608.19, 928, 800, 608, 480, 288 )
+polygons = [ PoolIntArray( 0, 1, 2, 3, 4, 5 ), PoolIntArray( 6, 7, 8, 9, 10, 11 ), PoolIntArray( 7, 6, 12, 3 ), PoolIntArray( 13, 4, 3, 12, 14 ), PoolIntArray( 15, 13, 16, 17 ), PoolIntArray( 18, 0, 5, 19 ), PoolIntArray( 19, 5, 15, 17 ), PoolIntArray( 20, 21, 22, 23 ), PoolIntArray( 20, 23, 24, 25 ), PoolIntArray( 25, 24, 26, 27 ), PoolIntArray( 26, 28, 29, 19, 17 ), PoolIntArray( 16, 13, 14, 30, 31 ), PoolIntArray( 31, 30, 32, 33 ), PoolIntArray( 30, 14, 34, 21 ), PoolIntArray( 10, 35, 11 ), PoolIntArray( 9, 36, 10 ), PoolIntArray( 34, 6, 11, 22 ), PoolIntArray( 34, 22, 21 ), PoolIntArray( 30, 21, 37 ), PoolIntArray( 26, 17, 33 ), PoolIntArray( 26, 33, 32, 38 ), PoolIntArray( 26, 38, 27 ), PoolIntArray( 25, 27, 30, 37 ) ]
+outlines = [ PoolVector2Array( 1384, -24, 1376, 96, 1752, 88, 1768, 160, 1832, 168, 1824, 416, 1752, 424, 1752, 576, 1824, 584, 1824, 928, 1608.19, 928, 1608, 864, 1504, 864, 1504, 736, 1376, 736, 1376, 1160, -360, 1160, -344, -168, 1392, -168 ), PoolVector2Array( 1376, 160, 1504, 160, 1504, 352, 1376, 352 ), PoolVector2Array( 1376, 480, 1504, 480, 1504, 672, 1376, 672 ), PoolVector2Array( 928, 96, 1120, 96, 1120, 288, 928, 288 ), PoolVector2Array( 800, 608, 992, 608, 992, 800, 800, 800 ), PoolVector2Array( 480, 288, 672, 288, 672, 480, 480, 480 ) ]
 
 [sub_resource type="RectangleShape2D" id=3]
 extents = Vector2( 264, 580 )
 
 [node name="Level1" type="CanvasLayer"]
 script = ExtResource( 1 )
+canThrowFoodOutsideKitchen = true
 level_name = "level1"
 
 [node name="TileMap" parent="." instance=ExtResource( 2 )]
@@ -55,11 +56,11 @@ position = Vector2( 1534, 916 )
 rotation = 1.5708
 
 [node name="IcecreamMachine" parent="." instance=ExtResource( 4 )]
-position = Vector2( 1816, 120 )
+position = Vector2( 1816, 500 )
 collision_layer = 1
 
 [node name="RiceCooker" parent="." instance=ExtResource( 7 )]
-position = Vector2( 1824, 920 )
+position = Vector2( 1824, 100 )
 
 [node name="EnemySpawnPoints" type="Node2D" parent="."]
 

--- a/DefendTheKitchen/Player.gd
+++ b/DefendTheKitchen/Player.gd
@@ -135,8 +135,7 @@ func ThrowFood():
 	if !canThrowFood:
 		return;
 	
-	#Food throwing sound
-	$ThrowingSound.play()
+
 	
 	#match statement with what is equipted currently to switch between things
 	match currentEquip:
@@ -148,7 +147,8 @@ func ThrowFood():
 				# spawn food in front of player
 				b.global_position = global_position + aimDirection * 30.0;
 				food_count["pizza"] -= 1
-				
+				#Food throwing sound
+				$ThrowingSound.play()
 				emit_signal("update_inventory", food_count,currentEquip)
 		2:
 			if food_count["icecream"] > 0:
@@ -158,7 +158,8 @@ func ThrowFood():
 				# spawn food in front of player
 				b.global_position = global_position + aimDirection * 30.0;
 				food_count["icecream"] -= 1
-				
+				#Food throwing sound
+				$ThrowingSound.play()				
 				emit_signal("update_inventory", food_count,currentEquip)
 		3:
 			if food_count["rice"] > 0:
@@ -168,7 +169,8 @@ func ThrowFood():
 				# spawn food in front of player
 				b.global_position = global_position + aimDirection * 30.0;
 				food_count["rice"] -= 1
-				
+				#Food throwing sound
+				$ThrowingSound.play()				
 				emit_signal("update_inventory", food_count,currentEquip)
 
 
@@ -201,7 +203,7 @@ func _on_Stove_pizza_added():
 	update_food("pizza")
 
 func _on_IcecreamMachine_icecream_added():
-	update_food("icecream")
+	update_food("icecream",3);
 	
 
 #controls interactions between the player and loot
@@ -212,7 +214,7 @@ func _on_ApplianceDetectionArea_area_entered(area):
 
 
 func _on_RiceCooker_rice_added():
-	update_food("rice",5);
+	update_food("rice",6);
 
 
 func _on_ApplianceDetectionArea_body_entered(body):

--- a/DefendTheKitchen/RiceCooker.gd
+++ b/DefendTheKitchen/RiceCooker.gd
@@ -71,5 +71,4 @@ func _upgrade():
 	self.upgradeCost += 10;
 	emit_signal("update_upgrade", upgradeCost);
 	
-	# TODO This is just an upgrade example
-	$RiceCookerTimer.wait_time -= 1;
+	$RiceCookerTimer.wait_time *= 0.75;

--- a/DefendTheKitchen/RiceCooker.tscn
+++ b/DefendTheKitchen/RiceCooker.tscn
@@ -16,6 +16,7 @@ extents = Vector2( 31.5, 33 )
 
 [node name="RiceCooker" type="StaticBody2D"]
 script = ExtResource( 1 )
+upgradeCost = 15
 
 [node name="Sprite" type="Sprite" parent="."]
 position = Vector2( -9.53674e-07, 1 )
@@ -33,7 +34,7 @@ position = Vector2( -0.5, 0 )
 shape = SubResource( 2 )
 
 [node name="RiceCookerTimer" type="Timer" parent="."]
-wait_time = 4.0
+wait_time = 3.5
 one_shot = true
 
 [node name="ProgressBar" type="TextureProgress" parent="."]

--- a/DefendTheKitchen/Stove.gd
+++ b/DefendTheKitchen/Stove.gd
@@ -70,5 +70,4 @@ func _upgrade():
 	self.upgradeCost += 10;
 	emit_signal("update_upgrade", upgradeCost);
 	
-	# TODO This is just an upgrade example
-	$StoveTimer.wait_time = 1;
+	$StoveTimer.wait_time *= 0.75;

--- a/DefendTheKitchen/Stove.tscn
+++ b/DefendTheKitchen/Stove.tscn
@@ -25,6 +25,7 @@ animations = [ {
 [node name="Stove" type="StaticBody2D"]
 collision_layer = 0
 script = ExtResource( 2 )
+upgradeCost = 15
 
 [node name="Area2D" type="Area2D" parent="."]
 
@@ -44,7 +45,7 @@ frames = SubResource( 1 )
 flip_v = true
 
 [node name="StoveTimer" type="Timer" parent="."]
-wait_time = 10.0
+wait_time = 20.0
 one_shot = true
 
 [node name="ProgressBar" type="TextureProgress" parent="."]

--- a/DefendTheKitchen/UpgradeButton.gd
+++ b/DefendTheKitchen/UpgradeButton.gd
@@ -26,7 +26,6 @@ func _on_Button_pressed():
 	player.mouseClickEnabled = false;
 	
 	if (player.gold >= appliance.upgradeCost):
-		
-		emit_signal("playerPressedUpgrade");
 		player.setGold(player.gold - appliance.upgradeCost);
+		emit_signal("playerPressedUpgrade");
 		updateButtonText(appliance.upgradeCost);


### PR DESCRIPTION
- Spread out the appliances. Ice cream in the middle, pizza and rice on opposite sides of kitchen. 
- Allow player to throw food outside of kitchen
- Updated wait times and upgrade costs for appliances
- Added 2 more waves before boss wave. This way, the player has more time to upgrade their appliances and be prepared
- Increased all enemies' speeds to make it a little more difficult for the player to outrun the enemies
- Disabled throwing food between waves so that player doesn't throw food when pressing "next wave" button
- fixed bug with the upgraded appliance's cost being subtracted from the player's gold rather than the cost of the upgrade when the player clicked on it
- Updated enemy navmesh to account for appliances
- Ice cream machine now gives three ice creams (enough to kill a base enemy)
- Rice cooker now gives 6 grains of rice (enough to kill 2 base enemies)
- Prevented enemy speed from becoming negative when frosted
- increased enemy status effect timer to be 4 seconds to give player more time to take advantage of slow movement
- Changed upgrade effect to set new wait time to be 75% of the previous wait time
- Made enemy attack windup shorter so player has less time to get out of the way
- Made throw sound only play if actually throwing food